### PR TITLE
feat: use shift-up/dwn for prev/next log in inspector view

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,10 @@ When using the `docker-service:` source, `docker service logs` is used to read l
 - `q` - Quit
 
 ### In Inspection View
-- `↑` or `↓` - Scroll inspection pane
+- `↑` or `↓` - Scroll inspection pane one line
+- `shift+↑` or `shift+↓` - Next/previous log item when in inspector view
+- `Ctrl+d` or `PageDown` - Scroll inspection pane down half page
+- `Ctrl+u` or `PageUp` - Scroll inspection pane up half page
 - `Enter` or `Esc` - Exit inspection view
 
 ## Log Format

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -190,6 +190,7 @@ const SHORTCUTS = [
   { key: '*', desc: 'Add new field to display' },
   { key: '\\', desc: 'Remove selected field from display' },
   { key: 'Enter', desc: 'Toggle detailed inspection view' },
+  { key: 'Shift+↓ / Shift+↑', desc: 'Next/previous log item when in inspector view' },
   { key: 'c', desc: 'Clear all messages' },
   { key: 'q', desc: 'Quit application' },
   { key: '?', desc: 'Show this help popup' },
@@ -301,6 +302,10 @@ function Main(props) {
     if (inspect) {
       if (key.escape || key.return) {
         setInspect(false)
+      } else if (key.shift && key.upArrow) {
+        move(-1)
+      } else if (key.shift && key.downArrow) {
+        move(1)
       }
       return
     }


### PR DESCRIPTION
When in inspector view you can use shift-up/down to go through the log items, without leaving the view